### PR TITLE
Optimize Test Workflow to Run Only on Relevant File Changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,23 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '*.mjs'
+      - '*.js'
+      - '*.ts'
+      - '.github/workflows/*.yml'
+      - 'package.json'
+      - 'tsconfig.json'
   pull_request:
     branches:
       - main
+    paths:
+      - '*.mjs'
+      - '*.js'
+      - '*.ts'
+      - '.github/workflows/*.yml'
+      - 'package.json'
+      - 'tsconfig.json'
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #109

This PR modifies the GitHub Actions workflow to trigger tests only when specific files are changed, reducing unnecessary test runs and saving CI resources. With this update, the tests will only run if any of the following files or patterns are modified:
- Files with extensions `.mjs, .js, .ts`
- `.github/workflows/*.yml`
- `package.json`
- `tsconfig.json`

## Changes Made:
- Updated `.github/workflow/test.yml` by adding paths filtering under push and pull_request triggers, specifying the relevant files to watch.
   ```yaml
    paths:
      - '*.mjs'
      - '*.js'
      - '*.ts'
      - '.github/workflows/*.yml'
      - 'package.json'
      - 'tsconfig.json'
   ```